### PR TITLE
🚀 Feature: REST API Integration

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -1,0 +1,64 @@
+name: CI - API Tests
+
+on: 
+    workflow_run:
+        workflows: ["C++ CI Build and Unit Tests"]
+        types:
+            - completed
+
+jobs:
+    api-tests:
+        name: REST API (cURL) Tests
+        runs-on: ubuntu-latest
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        
+        steps:
+            # Step 1: Checkout the repository
+            - name: Checkout code
+              uses: actions/checkout@v3
+
+            # Step 2: Install CMake
+            - name: Setup CMake
+              uses: jwlawson/actions-setup-cmake@v1
+              with:
+                cmake-version: '3.24.0'
+
+            # Step 3: Install dependencies (Linux only)
+            - name: Install build tools (Linux)
+              run: |
+                sudo apt-get update
+                sudo apt-get install -y g++ make libgtest-dev
+
+            # Step 4: Configure the build (force single-config everywhere)
+            - name: Configure project
+              run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -G "Ninja"
+
+            # Step 5: Build the project 
+            - name: Build project
+              run: cmake --build build
+
+            # Step 6: Start the API tests
+            - name: Run API Tests with curl
+              run: |
+                # Start the server in the background
+                ./build/DistributedCachePP --host 127.0.0.1 --port 5001 &
+                SERVER_PID=$!
+                sleep 2
+
+                echo "🔹 PUT foo=bar"
+                curl -s -X PUT http://127.0.0.1:5001/cache/foo \ -H "Content-Type: application/json" -d '{"value":"bar","ttl":500}' | tee output.json grep '"status":"ok"' output.json
+
+                echo "🔹 GET foo"
+                curl -s http://127.0.0.1:5001/cache/foo | grep "bar"
+
+                echo "🔹 DELETE foo"
+                curl -s -X DELETE http://127.0.0.1:5001/cache/foo | grep "deleted"
+
+                echo "🔹 GET foo (expect 404)" STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:5001/cache/foo) test "$STATUS" -eq 404
+
+                echo "🔹 PUT malformed JSON (expect 400)" STATUS=$(curl -s -o /dev/null -w "%{http_code}" \ -X PUT http://127.0.0.1:5001/cache/bad \ -H "Content-Type: application/json" \ -d '{"value": }') test "$STATUS" -eq 400
+
+                echo "🔹 GET metrics"
+                curl -s http://127.0.0.1:5001/metrics | grep "cache_hits_total"
+
+                kill $SERVER_PID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: C++ CI
+name: C++ CI Build and Unit Tests
 
 on:
     push:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,18 +54,27 @@ if(NOT json_POPULATED)
     set(JSON_INCLUDE_DIR ${json_SOURCE_DIR}/single_include CACHE INTERNAL "")
 endif()
 
-# Main Server binary
-add_executable(DistributedCachePP src/main.cpp src/api.cpp)
-target_include_directories(DistributedCachePP PRIVATE ${JSON_INCLUDE_DIR} include)
-target_link_libraries(DistributedCachePP PRIVATE cache httplib::httplib)
+# ------------- Library -----------------
+add_library(cache
+src/cache.cpp
+src/api.cpp
+ # add src/metrics.cpp when ready
+)
+target_include_directories(cache PRIVATE ${JSON_INCLUDE_DIR} include)
+target_link_libraries(cache PRIVATE cache httplib::httplib)
 
 # Add pthread only on UNIX
 if(UNIX)
     target_link_libraries(DistributedCachePP PRIVATE pthread)
 endif()
 
-# Tests
+# ---------- Main Server ----------
+add_executable(DistributedCachePP src/main.cpp)
+target_link_libraries(DistributedCachePP PRIVATE cache)
+
+# ---------- Tests ----------
 enable_testing()
-add_executable(CacheTests tests/cache_test.cpp)
-target_link_libraries(CacheTests PRIVATE cache gtest_main)
-add_test(NAME CacheTests COMMAND CacheTests)
+file(GLOB TEST_SOURCES tests/*.cpp)   # automatically pick up all test files
+add_executable(UnitTests ${TEST_SOURCES})
+target_link_libraries(UnitTests PRIVATE cache gtest_main)
+add_test(NAME UnitTests COMMAND UnitTests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.15)
 project(DistributedCachePP LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -32,12 +32,40 @@ FetchContent_Declare(
 )
 # Force GoogleTest to use same runtime library
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-
 FetchContent_MakeAvailable(googletest)
+
+# httplib (HTTP sever)
+FetchContent_Declare(
+    httplib
+    GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
+    GIT_TAG v0.15.3
+)
+FetchContent_MakeAvailable(httplib)
+
+# JSON (header-only, skip its CMakeLists.txt to avoid warnings)
+FetchContent_Declare(
+    json
+    URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+)
+FetchContent_GetProperties(json)
+if(NOT json_POPULATED)
+    FetchContent_Populate(json)
+    # only add its headers, don’t add_subdirectory
+    set(JSON_INCLUDE_DIR ${json_SOURCE_DIR}/single_include CACHE INTERNAL "")
+endif()
+
+# Main Server binary
+add_executable(DistributedCachePP src/main.cpp src/api.cpp)
+target_include_directories(DistributedCachePP PRIVATE ${JSON_INCLUDE_DIR} include)
+target_link_libraries(DistributedCachePP PRIVATE cache httplib::httplib)
+
+# Add pthread only on UNIX
+if(UNIX)
+    target_link_libraries(DistributedCachePP PRIVATE pthread)
+endif()
 
 # Tests
 enable_testing()
 add_executable(CacheTests tests/cache_test.cpp)
 target_link_libraries(CacheTests PRIVATE cache gtest_main)
-
 add_test(NAME CacheTests COMMAND CacheTests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,6 @@ endif()
 # Source and include directories
 include_directories(include)
 
-# Library directories
-add_library(cache src/cache.cpp)
-
 # Fetch GoogleTest
 include(FetchContent)
 FetchContent_Declare(
@@ -54,27 +51,32 @@ if(NOT json_POPULATED)
     set(JSON_INCLUDE_DIR ${json_SOURCE_DIR}/single_include CACHE INTERNAL "")
 endif()
 
-# ------------- Library -----------------
-add_library(cache
-src/cache.cpp
-src/api.cpp
- # add src/metrics.cpp when ready
-)
-target_include_directories(cache PRIVATE ${JSON_INCLUDE_DIR} include)
-target_link_libraries(cache PRIVATE cache httplib::httplib)
+# ---------------- Library ----------------
+add_library(DistributedCacheLib src/cache.cpp)
+target_include_directories(DistributedCacheLib PUBLIC include)
 
-# Add pthread only on UNIX
+# ---------------- Main Server Binary ----------------
+add_executable(DistributedCachePP src/main.cpp src/api.cpp)
+target_include_directories(DistributedCachePP PRIVATE ${JSON_INCLUDE_DIR} include)
+target_link_libraries(DistributedCachePP PRIVATE DistributedCacheLib httplib::httplib)
+
 if(UNIX)
     target_link_libraries(DistributedCachePP PRIVATE pthread)
 endif()
 
-# ---------- Main Server ----------
-add_executable(DistributedCachePP src/main.cpp)
-target_link_libraries(DistributedCachePP PRIVATE cache)
-
-# ---------- Tests ----------
+# ---------------- Tests ----------------
 enable_testing()
-file(GLOB TEST_SOURCES tests/*.cpp)   # automatically pick up all test files
-add_executable(UnitTests ${TEST_SOURCES})
-target_link_libraries(UnitTests PRIVATE cache gtest_main)
-add_test(NAME UnitTests COMMAND UnitTests)
+
+# Cache unit tests
+add_executable(CacheTests tests/cache_test.cpp)
+target_link_libraries(CacheTests PRIVATE DistributedCacheLib gtest_main)
+add_test(NAME CacheTests COMMAND CacheTests)
+
+# API integration tests
+add_executable(ApiTests tests/api_test.cpp src/api.cpp)
+target_include_directories(ApiTests PRIVATE ${JSON_INCLUDE_DIR} include)
+target_link_libraries(ApiTests PRIVATE DistributedCacheLib httplib::httplib gtest_main)
+if(UNIX)
+    target_link_libraries(ApiTests PRIVATE pthread)
+endif()
+add_test(NAME ApiTests COMMAND ApiTests)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ The system supports:
 - **Prometheus metrics** for observability
 
 ---
+## 🔍 CI Status
+
+- ✅ **Unit tests** run on **Linux, macOS, and Windows**.  
+- ✅ **API integration tests** verify REST endpoints using `curl`.
+---
 
 ## ✨ Features
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # DistributedCache++
 
-[![C++ CI](https://github.com/shashankbbalagavi20/DistributedCachePP/actions/workflows/ci.yml/badge.svg)](https://github.com/shashankbbalagavi20/DistributedCachePP/actions/workflows/ci.yml)
+[![Unit Tests](https://github.com/shashankbbalagavi20/DistributedCachePP/actions/workflows/ci.yml/badge.svg)](https://github.com/shashankbbalagavi20/DistributedCachePP/actions/workflows/ci.yml)
+[![API Tests](https://github.com/shashankbbalagavi20/DistributedCachePP/actions/workflows/api-tests.yml/badge.svg)](https://github.com/shashankbbalagavi20/DistributedCachePP/actions/workflows/api-tests.yml)
 
 **A production-grade C++17 distributed in-memory cache with LRU eviction, TTL expiration, leader–follower replication, sharding, REST API, and Prometheus metrics.**
 

--- a/include/api.h
+++ b/include/api.h
@@ -26,6 +26,10 @@ public:
     void start(const std::string& host, int port);
 
 private:
+    /**
+     * Log an incoming request with method, path, and status code
+     */
+    void logRequest(const std::string& method, const std::string& path, int status);
     std::shared_ptr<Cache> cache_;
     httplib::Server server_;
 };

--- a/include/api.h
+++ b/include/api.h
@@ -25,6 +25,10 @@ public:
      */
     void start(const std::string& host, int port);
 
+    /**
+     * Stop the HTTP server
+     */
+    void stop();
 private:
     /**
      * Log an incoming request with method, path, and status code

--- a/include/api.h
+++ b/include/api.h
@@ -1,0 +1,33 @@
+#pragma once
+#ifndef API_H
+#define API_H
+
+#include "cache.h"
+#include "httplib.h"
+#include <memory>
+#include <string>
+
+/**
+ * REST API wrapper around Cache
+ */
+class CacheAPI {
+public:
+    /**
+     * Constructor
+     * @param cache Shared pointer to Cache instance
+     */
+    explicit CacheAPI(std::shared_ptr<Cache> cache);
+
+    /**
+     * Start the HTTP server
+     * @param host Host to bind (default: "0.0.0.0")
+     * @param port Port to bind
+     */
+    void start(const std::string& host, int port);
+
+private:
+    std::shared_ptr<Cache> cache_;
+    httplib::Server server_;
+};
+
+#endif // API_H

--- a/include/cache.h
+++ b/include/cache.h
@@ -19,6 +19,7 @@
  * - TTL expiration (per key, in ms)
  * - Async background eviction (thread removes expired keys periodically)
  * - O(1) average complexity for get/put
+ * - Basic metrics: cache hits & misses
  */
 class Cache {
 public:
@@ -48,6 +49,7 @@ public:
 
     /**
      * Get value if present and not expired.
+     * Increments hit/miss counters for metrics.
      * @param key Key to fetch
      * @return std::optional containing value if hit, empty if miss
      */
@@ -91,6 +93,16 @@ public:
     */ 
     uint64_t eviction_interval() const;
 
+    /**
+     * @return Number of successful cache hits
+     */
+    size_t hits() const;
+
+    /**
+     * @return Number of cache misses
+     */
+    size_t misses() const;
+
 private:
     // ---------------- Internal types ----------------
 
@@ -121,6 +133,10 @@ private:
     std::thread eviction_thread_;
     std::atomic<bool> stop_eviction_{false};
     uint64_t eviction_interval_ms_;
+
+    // Metrics
+    std::atomic<size_t> hits_{0};               ///< Count of cache hits
+    std::atomic<size_t> misses_{0};            ///< Count of cache misses
 };
 
 #endif // CACHE_H

--- a/include/time_utils.h
+++ b/include/time_utils.h
@@ -1,0 +1,22 @@
+#pragma once
+#ifndef TIME_UTILS_H
+#define TIME_UTILS_H
+
+#include <ctime>
+
+/**
+ * Cross platform safe localtime wrapper.
+ * windows -> localtime_s
+ * Linux/Unix -> localtime_r
+ */
+inline std::tm safe_localtime(std::time_t time){
+    std::tm tm_buf{};
+#if defined(_WIN32) || defined(_WIN64)
+    localtime_s(&tm_buf, &time);
+#else
+    localtime_r(&time, &tm_buf);
+#endif
+    return tm_buf;
+}
+
+#endif // TIME_UTILS_H

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1,0 +1,62 @@
+#include "api.h"
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+CacheAPI::CacheAPI(std::shared_ptr<Cache> cache) : cache_(std::move(cache)) {}
+
+void CacheAPI::start(const std::string& host, int port){
+    // GET /cache/<key>
+    server_.Get(R"(/cache/(\w+))", [this](const httplib::Request& req, httplib::Response& res) {
+        auto key = req.matches[1];
+        auto val = cache_->get(key);
+        if(val.has_value()){
+            json j = {{"value", val.value()}};
+            res.set_content(j.dump(), "application/json");
+        } else {
+            res.status = 404; // Not Found
+            res.set_content(R"({"error": "not found"})", "application/json");
+        }
+    });
+
+    // PUT /cache/<key>
+    server_.Put(R"(/cache/(\w+))", [this](const httplib::Request& req, httplib::Response& res) {
+        try {
+            std::cerr << "Raw request body: " << req.body << std::endl; // DEBUG
+
+            auto key = req.matches[1];
+            auto body_json = json::parse(req.body);
+
+            if (!body_json.contains("value")) {
+                res.status = 400;
+                res.set_content(R"({"error": "missing 'value'"})", "application/json");
+                return;
+            }
+
+            std::string value = body_json["value"];
+            uint64_t ttl = body_json.value("ttl", 0);
+
+            cache_->put(key, value, ttl);
+            res.set_content(R"({"status": "ok"})", "application/json");
+        }
+        catch (const std::exception& e) {
+            res.status = 400;
+            res.set_content(std::string{"{\"error\": \""} + e.what() + "\"}", "application/json");
+        }
+    });
+
+    // DELETE /cache/<key>
+    server_.Delete(R"(/cache/(\w+))", [this](const httplib::Request& req, httplib::Response& res) {
+        auto key = req.matches[1];
+        if(cache_->erase(key)){
+            res.set_content(R"({"status": "deleted"})", "application/json");
+        }
+        else{
+            res.status = 404;
+            res.set_content(R"({"error": "not found"})", "application/json");
+        }
+    });
+
+    // Start server
+    server_.listen(host.c_str(), port);
+}

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -110,3 +110,9 @@ void CacheAPI::start(const std::string& host, int port){
     std::cerr << "🚀 Starting REST API on " << host << ":" << port << std::endl;
     server_.listen(host.c_str(), port);
 }
+
+// ✅ New stop() method so tests can cleanly shut down the server
+void CacheAPI::stop()
+{
+    server_.stop();
+}

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <chrono>
 #include <ctime>
+#include <time_utils.h>
 
 using json = nlohmann::json;
 
@@ -11,8 +12,7 @@ CacheAPI::CacheAPI(std::shared_ptr<Cache> cache) : cache_(std::move(cache)) {}
 void CacheAPI::logRequest(const std::string& method, const std::string& path, int status)
 {
     auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-    std::tm tm_buf;
-    localtime_s(&tm_buf, &now);
+    std::tm tm_buf = safe_localtime(now);
     std::cerr << "[" << std::put_time(&tm_buf, "%F %T") << "] "
     << method << " " << path << " -> " << status << std::endl;
 }

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -77,6 +77,7 @@ std::optional<std::string> Cache::get(const std::string& key){
 
     auto it = map_.find(key);
     if(it == map_.end()){
+        misses_++;
         return std::nullopt; // key not found
     }
 
@@ -85,10 +86,12 @@ std::optional<std::string> Cache::get(const std::string& key){
         // Key is expired
         lru_list_.erase(it->second.lru_it); // Remove from LRU list
         map_.erase(it); // Remove from map
+        misses_++;
         return std::nullopt;  // Return empty optional
     }
 
     touch_to_front(it); // Move to front of LRU List
+    hits_++; 
     return it->second.value; // Return the value
 }
 
@@ -143,6 +146,14 @@ size_t Cache::capacity() const {
 
 uint64_t Cache::eviction_interval() const {
     return eviction_interval_ms_;
+}
+
+size_t Cache::hits() const {
+    return hits_.load();
+}
+
+size_t Cache::misses() const {
+    return misses_.load();
 }
 
 // Async eviction

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,12 @@
+#include "api.h"
+#include <iostream>
+#include <memory>
+
+int main() {
+    auto cache = std::make_shared<Cache>(100); // capacity 100
+    CacheAPI api(cache);
+
+    std::cout << "🚀 Starting server on http://localhost:5000" << std::endl;
+    api.start("0.0.0.0", 5000);
+    return 0;
+}

--- a/tests/api_test.cpp
+++ b/tests/api_test.cpp
@@ -15,7 +15,7 @@ TEST(ApiTest, BasicCRUD){
     });
 
     // Give server time to start
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
     httplib::Client cli("127.0.0.1", 5001);
 
@@ -47,7 +47,7 @@ TEST(ApiTest, BasicCRUD){
     EXPECT_EQ(metrics_res->status, 200);
     EXPECT_NE(metrics_res->body.find("cache_hits_total"), std::string::npos);
 
-    // Cleanup
-    // Stop server by terminating the process
-    std::terminate(); // For now: abrupt exit to stop blocking server thread
+    // Clean shutdown
+    api.stop();
+    server_thread.join();
 }

--- a/tests/api_test.cpp
+++ b/tests/api_test.cpp
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+#include <thread>
+#include <chrono>
+#include "../include/cache.h"
+#include "../include/api.h"
+#include <httplib.h>
+
+TEST(ApiTest, BasicCRUD){
+    auto cache = std::make_shared<Cache>(10);
+    CacheAPI api(cache);
+
+    // Run server in background thread
+    std::thread server_thread([&api]() {
+        api.start("127.0.0.1", 5001);
+    });
+
+    // Give server time to start
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    httplib::Client cli("127.0.0.1", 5001);
+
+    // PUT
+    auto put_res = cli.Put("/cache/foo", "{\"value\":\"bar\",\"ttl\":500}", "application/json");
+    ASSERT_TRUE(put_res != nullptr);
+    EXPECT_EQ(put_res->status, 200);
+    EXPECT_NE(put_res->body.find("\"status\":\"ok\""), std::string::npos);
+
+    // GET
+    auto get_res = cli.Get("/cache/foo");
+    ASSERT_TRUE(get_res != nullptr);
+    EXPECT_EQ(get_res->status, 200);
+    EXPECT_NE(get_res->body.find("\"bar\""), std::string::npos);
+
+    // DELETE
+    auto del_res = cli.Delete("/cache/foo");
+    ASSERT_TRUE(del_res != nullptr);
+    EXPECT_EQ(del_res->status, 200);
+
+    // GET again (should be 404)
+    auto get_res2 = cli.Get("/cache/foo");
+    ASSERT_TRUE(get_res2 != nullptr);
+    EXPECT_EQ(get_res2->status, 404);
+
+    // Check metrics
+    auto metrics_res = cli.Get("/metrics");
+    ASSERT_TRUE(metrics_res != nullptr);
+    EXPECT_EQ(metrics_res->status, 200);
+    EXPECT_NE(metrics_res->body.find("cache_hits_total"), std::string::npos);
+
+    // Cleanup
+    // Stop server by terminating the process
+    std::terminate(); // For now: abrupt exit to stop blocking server thread
+}

--- a/tests/api_test.cpp
+++ b/tests/api_test.cpp
@@ -62,3 +62,19 @@ TEST(ApiTest, BasicCRUD){
     api.stop();
     server_thread.join();
 }
+
+TEST(ApiTest, InvalidPut) {
+    auto cache = std::make_shared<Cache>(10);
+    CacheAPI api(cache);
+    std::thread server_thread([&api]() { api.start("127.0.0.1", 5002); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    httplib::Client cli("127.0.0.1", 5002);
+    auto res = cli.Put("/cache/foo", "not-json", "application/json");
+
+    ASSERT_TRUE(res != nullptr);
+    EXPECT_EQ(res->status, 400);
+
+    api.stop();
+    server_thread.join();
+}


### PR DESCRIPTION
This PR introduces a fully functional **REST API** layer on top of the cache library.  
The API allows clients to interact with the cache over HTTP, making it easier to test and integrate with other systems.

---

## ✅ What’s Included
- **REST Endpoints**
  - `PUT /cache/<key>` → store a value (with optional TTL)
  - `GET /cache/<key>` → retrieve a value
  - `DELETE /cache/<key>` → remove a value
  - `GET /metrics` → Prometheus-compatible cache metrics (hits, misses, size, capacity, eviction interval)

- **Integration Tests**
  - `ApiTests` using GoogleTest + `httplib`
  - Server start/stop handled gracefully within tests
  - Black-box `curl`-based tests in CI to validate endpoints end-to-end

- **Cross-Platform CI**
  - Verified on **Linux**, **macOS**, and **Windows**
  - Runs both `CacheTests` and `ApiTests`

---

## 📖 Example Usage

```bash
# Start server
./DistributedCachePP --host 127.0.0.1 --port 5001

# Put a value
curl -X PUT http://127.0.0.1:5001/cache/foo -d '{"value":"bar","ttl":500}' -H "Content-Type: application/json"

# Get the value
curl http://127.0.0.1:5001/cache/foo

# Delete the value
curl -X DELETE http://127.0.0.1:5001/cache/foo

# Metrics
curl http://127.0.0.1:5001/metrics
